### PR TITLE
build: upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,16 @@
   },
   "homepage": "https://github.com/rvagg/js-datastore-car#readme",
   "devDependencies": {
-    "bl": "^4.0.0",
+    "bl": "^4.0.2",
     "garbage": "0.0.0",
     "hundreds": "0.0.2",
-    "mocha": "^6.2.2"
+    "mocha": "^7.1.1"
   },
   "dependencies": {
-    "@ipld/block": "^2.1.3",
-    "cids": "^0.7.1",
-    "interface-datastore": "^0.8.0",
-    "multicodec": "^1.0.0",
+    "@ipld/block": "^4.0.0",
+    "cids": "^0.8.0",
+    "interface-datastore": "^0.8.3",
+    "multicodec": "^1.0.1",
     "varint": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datastore-car",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Content ARchive format reader and writer",
   "main": "car.js",
   "browser": "car-browser.js",


### PR DESCRIPTION
I pushed a new version of the Block API that drops eth from the default set of codecs in Node.js (they were already excluded from the browser version).

Long story short, the eth dependencies include some old level libraries that get hoisted even when the package is a dep of a dep. This is causing some very problematic issues in bundlers depending on your settings and bundler version (the issue is present in whatever the config is for polendina so I can reproduce it consistently). Even worse, you don’t see this in any browser tests that don’t try to **use leveldb in the tests** so it’s totally transparent to all of our dep’s browser tests until a project tries to use their own level modules.

Anyway, I went ahead and ran an update of all the deps and Node.js tests are passing.