### PR TITLE
remove `CID#toBaseEncodeString()`, update deps

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,9 +13,7 @@ function toKey (key, method) {
 }
 
 function cidToKey (cid) {
-  // toBaseEncodedString() is supposed to do this automatically but let's be explicit to be
-  // sure & future-proof
-  return cid.toBaseEncodedString(cid.version === 0 ? 'base58btc' : 'base32')
+  return cid.toString() // cidv0 gets base58btc, v1 gets base32
 }
 
 function verifyRoots (roots) {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "test": "test"
   },
   "scripts": {
-    "lint": "npx standard",
-    "test:browser": "npx polendina --cleanup test/test-readbuffer.js test/test-query.js",
+    "lint": "standard",
+    "test:browser": "polendina --cleanup test/test-readbuffer.js test/test-query.js",
     "test:node": "hundreds mocha test/test-*.js",
     "test": "npm run lint && npm run test:node && npm run test:browser",
-    "docs": "npx jsdoc4readme --readme *.js lib/raw.js"
+    "docs": "jsdoc4readme --readme *.js lib/raw.js"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,10 @@
     "bl": "^4.0.2",
     "garbage": "0.0.0",
     "hundreds": "0.0.2",
-    "mocha": "^7.1.2"
+    "jsdoc4readme": "^1.3.0",
+    "mocha": "^7.1.2",
+    "polendina": "^1.0.0",
+    "standard": "^14.3.3"
   },
   "dependencies": {
     "@ipld/block": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "bl": "^4.0.2",
     "garbage": "0.0.0",
     "hundreds": "0.0.2",
-    "mocha": "^7.1.1"
+    "mocha": "^7.1.2"
   },
   "dependencies": {
-    "@ipld/block": "^4.0.0",
+    "@ipld/block": "^4.0.2",
     "cids": "^0.8.0",
-    "interface-datastore": "^0.8.3",
+    "interface-datastore": "^1.0.2",
     "multicodec": "^1.0.1",
     "varint": "^5.0.0"
   }


### PR DESCRIPTION
@mikeal "deprecated" (throws!) `toBaseEncodedString()` on js-multiformats, so it's not usable here. Ironic given the comment in here about "future proofing".

Also update deps and ditch use of `npx` to run some dev dep tooling.